### PR TITLE
Add a /pronouns route

### DIFF
--- a/backend/api.ts
+++ b/backend/api.ts
@@ -31,11 +31,13 @@ import oauthModule from './api/oauth'
 import accountModule from './api/account'
 import lookupModule from './api/lookup'
 import adminModule from './api/admin'
+import pronounsModule from './api/pronouns'
 
 export default async function (fastify: FastifyInstance) {
   fastify.register(adminModule, { prefix: '/admin' })
   fastify.register(oauthModule, { prefix: '/oauth' })
   fastify.register(accountModule, { prefix: '/accounts' })
   fastify.register(lookupModule)
+  fastify.register(pronounsModule)
   fastify.get('*', (_, reply) => void reply.send({ error: 404, message: 'Not Found' }))
 }

--- a/backend/api/pronouns.ts
+++ b/backend/api/pronouns.ts
@@ -1,0 +1,11 @@
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { Pronouns } from '../shared';
+
+async function pronouns (this: FastifyInstance, _: FastifyRequest, reply: FastifyReply) {
+  reply.header('access-control-allow-origin', '*')
+  reply.send(Pronouns)
+}
+
+export default async function (fastify: FastifyInstance) {
+  fastify.get('/pronouns', pronouns)
+}

--- a/frontend/src/components/Docs.tsx
+++ b/frontend/src/components/Docs.tsx
@@ -86,6 +86,12 @@ function Docs (_: RoutableProps) {
         </ul>
         <p>Response: A map of IDs with their corresponding set of pronouns. IDs not found will not be included.</p>
       </div>
+
+      <h3>List all supported pronouns</h3>
+      <div>
+        <p>GET /api/v1/pronouns</p>
+        <p>Response: A map of pronoun abbreviations with their corresponding set of pronouns.</p>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
This PR adds a `/pronouns` route to the public API that allows developers to get an up-to-date map of pronoun abbreviations with their corresponding set of pronouns. This is achieved by just sending the [`Pronouns`](https://github.com/cyyynthia/pronoundb.org/blob/mistress/extension/shared.ts#L101-L125) object as the response body.
This is especially useful to prevent software that depends on the pronoundb.org API from breaking in the future just because a new pronoun was added, which wasn't yet added to the software's own hard coded map of pronoun abbreviations.