### PR TITLE
Fix .eslintrc

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "env": {
     "es2021": true,
     "node": true


### PR DESCRIPTION
This tells ESLint not to look in parent directories for config, fixing this error:

```
Oops! Something went wrong! :(

ESLint: 8.3.0

ESLint couldn't determine the plugin "@typescript-eslint" uniquely.

- .../pronoundb.org/node_modules/.pnpm/@typescript-eslint+eslint-plugin@5.4.0_5c8ff4cecd5a55e744866c0654edac32/node_modules/@typescript-eslint/eslint-plugin/dist/index.js (loaded in ".eslintrc.json » ../../.eslintrc.json")
- .../pronoundb.org/node_modules/.pnpm/@typescript-eslint+eslint-plugin@5.4.0_098db790fe293b2eb3e369319b13bb04/node_modules/@typescript-eslint/eslint-plugin/dist/index.js (loaded in "../../.eslintrc.json")

Please remove the "plugins" setting from either config or remove either plugin installation.
```