### PR TITLE
General Fixes on 

### DIFF
--- a/packages/extension/src/modules/modrinth.ts
+++ b/packages/extension/src/modules/modrinth.ts
@@ -37,7 +37,7 @@ import { h, css } from '../utils/dom'
 export const name = 'Modrinth'
 export const color = '#30B27B'
 export const match = /^https:\/\/modrinth\.com/
-export { default as Icon } from '../../assets/modrinth.svg'
+export { default as Icon } from '@assets/modrinth.svg'
 
 async function fetchUntilData (el: HTMLElement, queries: QueryElement[][]) {
   for (let i = 1; i < 20; i++) {

--- a/packages/website/src/components/Footer.astro
+++ b/packages/website/src/components/Footer.astro
@@ -29,7 +29,7 @@
 
 import Link from './Link.astro'
 import Heart from './Heart.astro'
-import pawSvg from '../assets/paw.svg?raw'
+import pawSvg from '@assets/paw.svg?raw'
 ---
 <footer class='container flex flex-none flex-wrap items-center justify-between gap-x-6 gap-y-2 mx-auto p-3 border-t border-gray-200 dark:border-gray-700'>
   <div class='flex flex-none items-center gap-2 text-gray-600 dark:text-gray-400'>

--- a/packages/website/src/components/Header.astro
+++ b/packages/website/src/components/Header.astro
@@ -27,7 +27,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { hasValidToken, createCsrf } from '../server/auth.js'
+import { hasValidToken, createCsrf } from '@server/auth.js'
 import Link from './Link.astro'
 
 const authenticated = hasValidToken(Astro)

--- a/packages/website/src/components/Stars.astro
+++ b/packages/website/src/components/Stars.astro
@@ -27,7 +27,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import starSvg from '../assets/star.svg?raw'
+import starSvg from '@assets/star.svg?raw'
 
 export type Store = 'chrome' | 'firefox' | 'edge'
 

--- a/packages/website/src/components/platforms/minecraft.ts
+++ b/packages/website/src/components/platforms/minecraft.ts
@@ -26,7 +26,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import minecraft from '../../assets/minecraft.svg?raw'
+import minecraft from '@assets/minecraft.svg?raw'
 
 export const name = 'Minecraft'
 export const color = '#854F2B'

--- a/packages/website/src/components/platforms/modrinth.ts
+++ b/packages/website/src/components/platforms/modrinth.ts
@@ -26,7 +26,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import modrinth from '../../assets/modrinth.svg?raw'
+import modrinth from '@assets/modrinth.svg?raw'
 
 export const name = 'Modrinth'
 export const color = '#30B27B'

--- a/packages/website/src/layouts/Layout.astro
+++ b/packages/website/src/layouts/Layout.astro
@@ -27,8 +27,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import Header from '../components/Header.astro'
-import Footer from '../components/Footer.astro'
+import Header from '@components/Header.astro'
+import Footer from '@components/Footer.astro'
 
 import alertSvg from 'feather-icons/dist/icons/alert-circle.svg?raw'
 import checkSvg from 'feather-icons/dist/icons/check-circle.svg?raw'

--- a/packages/website/src/pages/404.astro
+++ b/packages/website/src/pages/404.astro
@@ -31,7 +31,7 @@ import { migrateAuth } from '@server/auth.js'
 migrateAuth(Astro)
 
 import { handleFlash } from '@server/flash.js'
-import { data } from '../assets/cat-facts.json'
+import { data } from '@assets/cat-facts.json'
 
 import Layout from '@layouts/Layout.astro'
 import PageHeader from '@components/PageHeader.astro'

--- a/packages/website/src/pages/404.astro
+++ b/packages/website/src/pages/404.astro
@@ -27,15 +27,15 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { migrateAuth } from '../server/auth.js'
+import { migrateAuth } from '@server/auth.js'
 migrateAuth(Astro)
 
-import { handleFlash } from '../server/flash.js'
+import { handleFlash } from '@server/flash.js'
 import { data } from '../assets/cat-facts.json'
 
-import Layout from '../layouts/Layout.astro'
-import PageHeader from '../components/PageHeader.astro'
-import Link from '../components/Link.astro'
+import Layout from '@layouts/Layout.astro'
+import PageHeader from '@components/PageHeader.astro'
+import Link from '@components/Link.astro'
 
 const fact = data[Math.random() * data.length | 0]
 const flash = handleFlash(Astro)

--- a/packages/website/src/pages/api/v1/lookup-bulk.ts
+++ b/packages/website/src/pages/api/v1/lookup-bulk.ts
@@ -27,7 +27,7 @@
  */
 
 import type { APIContext } from 'astro'
-import { type PronounsOfUser, findPronounsOf } from '../../../server/database/account.js'
+import { type PronounsOfUser, findPronounsOf } from '@server/database/account.js'
 
 export async function get (ctx: APIContext) {
   const platform = ctx.url.searchParams.get('platform')

--- a/packages/website/src/pages/api/v1/lookup/index.ts
+++ b/packages/website/src/pages/api/v1/lookup/index.ts
@@ -27,7 +27,7 @@
  */
 
 import type { APIContext } from 'astro'
-import { findPronounsOf } from '../../../../server/database/account.js'
+import { findPronounsOf } from '@server/database/account.js'
 
 export async function get (ctx: APIContext) {
   const platform = ctx.url.searchParams.get('platform')

--- a/packages/website/src/pages/api/v1/lookup/me.ts
+++ b/packages/website/src/pages/api/v1/lookup/me.ts
@@ -27,7 +27,7 @@
  */
 
 import type { APIContext } from 'astro'
-import { authenticate } from '../../../../server/auth.js'
+import { authenticate } from '@server/auth.js'
 
 function getCorsHeaders (request: APIContext['request']) {
   const origin = request.headers.get('origin')

--- a/packages/website/src/pages/docs.astro
+++ b/packages/website/src/pages/docs.astro
@@ -27,14 +27,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { migrateAuth } from '../server/auth.js'
+import { migrateAuth } from '@server/auth.js'
 migrateAuth(Astro)
 
-import { handleFlash } from '../server/flash.js'
+import { handleFlash } from '@server/flash.js'
 
-import Layout from '../layouts/Layout.astro'
-import PageHeader from '../components/PageHeader.astro'
-import Link from '../components/Link.astro'
+import Layout from '@layouts/Layout.astro'
+import PageHeader from '@components/PageHeader.astro'
+import Link from '@components/Link.astro'
 
 const providersGlob = import.meta.glob('../server/oauth/platforms/*.ts', { eager: true, import: '__null' })
 const providers = Object.keys(providersGlob).map((k) => k.slice(26, -3))

--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -27,21 +27,21 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { migrateAuth } from '../server/auth.js'
+import { migrateAuth } from '@server/auth.js'
 migrateAuth(Astro)
 
-import * as twitter from '../components/platforms/twitter.js'
-import * as twitch from '../components/platforms/twitch.js'
-import * as github from '../components/platforms/github.js'
+import * as twitter from '@components/platforms/twitter.js'
+import * as twitch from '@components/platforms/twitch.js'
+import * as github from '@components/platforms/github.js'
 
-import { handleFlash } from '../server/flash.js'
-import getStats from '../server/stats.js'
+import { handleFlash } from '@server/flash.js'
+import getStats from '@server/stats.js'
 
-import Layout from '../layouts/Layout.astro'
-import Link from '../components/Link.astro'
-import StoreButton from '../components/StoreButton.astro'
-import PlatformGrid from '../components/PlatformGrid.astro'
-import Platform from '../components/Platform.astro'
+import Layout from '@layouts/Layout.astro'
+import Link from '@components/Link.astro'
+import StoreButton from '@components/StoreButton.astro'
+import PlatformGrid from '@components/PlatformGrid.astro'
+import Platform from '@components/Platform.astro'
 
 import globeSvg from 'feather-icons/dist/icons/globe.svg?raw'
 

--- a/packages/website/src/pages/legal.astro
+++ b/packages/website/src/pages/legal.astro
@@ -27,13 +27,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { migrateAuth } from '../server/auth.js'
+import { migrateAuth } from '@server/auth.js'
 migrateAuth(Astro)
 
-import { handleFlash } from '../server/flash.js'
+import { handleFlash } from '@server/flash.js'
 
-import Layout from '../layouts/Layout.astro'
-import PageHeader from '../components/PageHeader.astro'
+import Layout from '@layouts/Layout.astro'
+import PageHeader from '@components/PageHeader.astro'
 const flash = handleFlash(Astro)
 ---
 <Layout flash={flash} title='Legal Notice'>

--- a/packages/website/src/pages/login.astro
+++ b/packages/website/src/pages/login.astro
@@ -27,11 +27,11 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { handleFlash } from '../server/flash.js'
+import { handleFlash } from '@server/flash.js'
 
-import Layout from '../layouts/Layout.astro'
-import PageHeader from '../components/PageHeader.astro'
-import OAuthProviderList from '../components/OAuthProviderList.astro'
+import Layout from '@layouts/Layout.astro'
+import PageHeader from '@components/PageHeader.astro'
+import OAuthProviderList from '@components/OAuthProviderList.astro'
 
 if (Astro.cookies.has('token')) return Astro.redirect('/me')
 const flash = handleFlash(Astro)

--- a/packages/website/src/pages/logout.ts
+++ b/packages/website/src/pages/logout.ts
@@ -27,8 +27,8 @@
  */
 
 import type { APIContext } from 'astro'
-import { validateCsrf } from '../server/auth.js'
-import { setFlash } from '../server/flash.js'
+import { validateCsrf } from '@server/auth.js'
+import { setFlash } from '@server/flash.js'
 
 export async function post (ctx: APIContext) {
   const body = await ctx.request.formData().catch(() => null)

--- a/packages/website/src/pages/me/delete.ts
+++ b/packages/website/src/pages/me/delete.ts
@@ -27,9 +27,9 @@
  */
 
 import type { APIContext } from 'astro'
-import { authenticate, validateCsrf } from '../../server/auth.js'
-import { setFlash } from '../../server/flash.js'
-import { deleteAccount } from '../../server/database/account.js'
+import { authenticate, validateCsrf } from '@server/auth.js'
+import { setFlash } from '@server/flash.js'
+import { deleteAccount } from '@server/database/account.js'
 
 export async function post (ctx: APIContext) {
   const user = await authenticate(ctx)

--- a/packages/website/src/pages/me/index.astro
+++ b/packages/website/src/pages/me/index.astro
@@ -27,17 +27,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { migrateAuth } from '../../server/auth.js'
+import { migrateAuth } from '@server/auth.js'
 migrateAuth(Astro)
 
-import { authenticate, createCsrf } from '../../server/auth.js'
-import { handleFlash } from '../../server/flash.js'
+import { authenticate, createCsrf } from '@server/auth.js'
+import { handleFlash } from '@server/flash.js'
 
-import Layout from '../../layouts/Layout.astro'
-import PageHeader from '../../components/PageHeader.astro'
-import Link from '../../components/Link.astro'
-import LegacyPronounsSelector from '../../components/LegacyPronounsSelector.astro'
-import Platform from '../../components/Platform.astro'
+import Layout from '@layouts/Layout.astro'
+import PageHeader from '@components/PageHeader.astro'
+import Link from '@components/Link.astro'
+import LegacyPronounsSelector from '@components/LegacyPronounsSelector.astro'
+import Platform from '@components/Platform.astro'
 
 import userPlusSvg from 'feather-icons/dist/icons/user-plus.svg?raw'
 import xSvg from 'feather-icons/dist/icons/x.svg?raw'

--- a/packages/website/src/pages/me/link.astro
+++ b/packages/website/src/pages/me/link.astro
@@ -27,15 +27,15 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { migrateAuth } from '../../server/auth.js'
+import { migrateAuth } from '@server/auth.js'
 migrateAuth(Astro)
 
-import { authenticate } from '../../server/auth.js'
-import { handleFlash } from '../../server/flash.js'
+import { authenticate } from '@server/auth.js'
+import { handleFlash } from '@server/flash.js'
 
-import Layout from '../../layouts/Layout.astro'
-import PageHeader from '../../components/PageHeader.astro'
-import OAuthProviderList from '../../components/OAuthProviderList.astro'
+import Layout from '@layouts/Layout.astro'
+import PageHeader from '@components/PageHeader.astro'
+import OAuthProviderList from '@components/OAuthProviderList.astro'
 
 const user = await authenticate(Astro)
 if (!user) return Astro.redirect('/')

--- a/packages/website/src/pages/me/set-pronouns.ts
+++ b/packages/website/src/pages/me/set-pronouns.ts
@@ -27,8 +27,8 @@
  */
 
 import type { APIContext } from 'astro'
-import { authenticate } from '../../server/auth.js'
-import { updatePronouns } from '../../server/database/account.js'
+import { authenticate } from '@server/auth.js'
+import { updatePronouns } from '@server/database/account.js'
 
 const LEGACY_PRONOUNS = [
   'hh', 'hi', 'hs', 'ht', 'ih', 'ii', 'is', 'it', 'shh', 'sh', 'si',

--- a/packages/website/src/pages/me/unlink-account.ts
+++ b/packages/website/src/pages/me/unlink-account.ts
@@ -27,9 +27,9 @@
  */
 
 import type { APIContext } from 'astro'
-import { authenticate, validateCsrf } from '../../server/auth.js'
-import { setFlash } from '../../server/flash.js'
-import { removeLinkedAccount } from '../../server/database/account.js'
+import { authenticate, validateCsrf } from '@server/auth.js'
+import { setFlash } from '@server/flash.js'
+import { removeLinkedAccount } from '@server/database/account.js'
 
 export async function post (ctx: APIContext) {
   const user = await authenticate(ctx)

--- a/packages/website/src/pages/oauth/[platform]/authorize.ts
+++ b/packages/website/src/pages/oauth/[platform]/authorize.ts
@@ -28,9 +28,9 @@
 
 import type { APIContext } from 'astro'
 
-import { authenticate } from '../../../server/auth.js'
-import { type OAuth1Params, authorize as authorize1 } from '../../../server/oauth/core/oauth10a.js'
-import { type OAuth2Params, authorize as authorize2 } from '../../../server/oauth/core/oauth2.js'
+import { authenticate } from '@server/auth.js'
+import { type OAuth1Params, authorize as authorize1 } from '@server/oauth/core/oauth10a.js'
+import { type OAuth2Params, authorize as authorize2 } from '@server/oauth/core/oauth2.js'
 
 type Params = OAuth1Params | OAuth2Params
 const INTENTS = [ 'register', 'login', 'link' ]

--- a/packages/website/src/pages/oauth/[platform]/callback.ts
+++ b/packages/website/src/pages/oauth/[platform]/callback.ts
@@ -28,11 +28,11 @@
 
 import type { APIContext } from 'astro'
 
-import { generateToken, authenticate } from '../../../server/auth.js'
-import { type FlashMessage, setFlash } from '../../../server/flash.js'
-import { type ExternalAccount, createAccount, findByExternalAccount, addLinkedAccount } from '../../../server/database/account.js'
-import { type OAuth1Params, callback as callback1 } from '../../../server/oauth/core/oauth10a.js'
-import { type OAuth2Params, callback as callback2 } from '../../../server/oauth/core/oauth2.js'
+import { generateToken, authenticate } from '@server/auth.js'
+import { type FlashMessage, setFlash } from '@server/flash.js'
+import { type ExternalAccount, createAccount, findByExternalAccount, addLinkedAccount } from '@server/database/account.js'
+import { type OAuth1Params, callback as callback1 } from '@server/oauth/core/oauth10a.js'
+import { type OAuth2Params, callback as callback2 } from '@server/oauth/core/oauth2.js'
 
 type Params = OAuth1Params | OAuth2Params
 const INTENTS = [ 'register', 'login', 'link' ]

--- a/packages/website/src/pages/onboarding.astro
+++ b/packages/website/src/pages/onboarding.astro
@@ -27,16 +27,16 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { migrateAuth } from '../server/auth.js'
+import { migrateAuth } from '@server/auth.js'
 migrateAuth(Astro)
 
-import { hasValidToken } from '../server/auth.js'
-import { handleFlash } from '../server/flash.js'
+import { hasValidToken } from '@server/auth.js'
+import { handleFlash } from '@server/flash.js'
 
-import Layout from '../layouts/Layout.astro'
-import PageHeader from '../components/PageHeader.astro'
-import Link from '../components/Link.astro'
-import Heart from '../components/Heart.astro'
+import Layout from '@layouts/Layout.astro'
+import PageHeader from '@components/PageHeader.astro'
+import Link from '@components/Link.astro'
+import Heart from '@components/Heart.astro'
 
 const authenticated = hasValidToken(Astro)
 

--- a/packages/website/src/pages/privacy.astro
+++ b/packages/website/src/pages/privacy.astro
@@ -27,13 +27,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { migrateAuth } from '../server/auth.js'
+import { migrateAuth } from '@server/auth.js'
 migrateAuth(Astro)
 
-import { handleFlash } from '../server/flash.js'
+import { handleFlash } from '@server/flash.js'
 
-import Layout from '../layouts/Layout.astro'
-import PageHeader from '../components/PageHeader.astro'
+import Layout from '@layouts/Layout.astro'
+import PageHeader from '@components/PageHeader.astro'
 
 const flash = handleFlash(Astro)
 ---

--- a/packages/website/src/pages/pronouns-101.astro
+++ b/packages/website/src/pages/pronouns-101.astro
@@ -27,14 +27,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { migrateAuth } from '../server/auth.js'
+import { migrateAuth } from '@server/auth.js'
 migrateAuth(Astro)
 
-import { handleFlash } from '../server/flash.js'
+import { handleFlash } from '@server/flash.js'
 
-import Layout from '../layouts/Layout.astro'
-import PageHeader from '../components/PageHeader.astro'
-import Link from '../components/Link.astro'
+import Layout from '@layouts/Layout.astro'
+import PageHeader from '@components/PageHeader.astro'
+import Link from '@components/Link.astro'
 
 const flash = handleFlash(Astro)
 ---

--- a/packages/website/src/pages/register.astro
+++ b/packages/website/src/pages/register.astro
@@ -27,15 +27,15 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { migrateAuth } from '../server/auth.js'
+import { migrateAuth } from '@server/auth.js'
 migrateAuth(Astro)
 
-import { handleFlash } from '../server/flash.js'
+import { handleFlash } from '@server/flash.js'
 
-import Layout from '../layouts/Layout.astro'
-import PageHeader from '../components/PageHeader.astro'
-import Link from '../components/Link.astro'
-import OAuthProviderList from '../components/OAuthProviderList.astro'
+import Layout from '@layouts/Layout.astro'
+import PageHeader from '@components/PageHeader.astro'
+import Link from '@components/Link.astro'
+import OAuthProviderList from '@components/OAuthProviderList.astro'
 
 if (Astro.cookies.has('token')) return Astro.redirect('/me')
 const flash = handleFlash(Astro)

--- a/packages/website/src/pages/shields/[id].json.ts
+++ b/packages/website/src/pages/shields/[id].json.ts
@@ -28,7 +28,7 @@
 
 import type { APIContext } from 'astro'
 import { ObjectId } from 'mongodb'
-import { findById } from '../../server/database/account.js'
+import { findById } from '@server/database/account.js'
 
 export const LegacyPronouns: Record<string, string | string[]> = {
   // -- Contributors: please keep the list sorted alphabetically.

--- a/packages/website/src/pages/supported.astro
+++ b/packages/website/src/pages/supported.astro
@@ -27,16 +27,16 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { migrateAuth } from '../server/auth.js'
+import { migrateAuth } from '@server/auth.js'
 migrateAuth(Astro)
 
-import { handleFlash } from '../server/flash.js'
+import { handleFlash } from '@server/flash.js'
 
-import Layout from '../layouts/Layout.astro'
-import PageHeader from '../components/PageHeader.astro'
-import PlatformGrid from '../components/PlatformGrid.astro'
-import Platform from '../components/Platform.astro'
-import Link from '../components/Link.astro'
+import Layout from '@layouts/Layout.astro'
+import PageHeader from '@components/PageHeader.astro'
+import PlatformGrid from '@components/PlatformGrid.astro'
+import Platform from '@components/Platform.astro'
+import Link from '@components/Link.astro'
 
 type PlatformInfo = {
   name: string

--- a/packages/website/tsconfig.json
+++ b/packages/website/tsconfig.json
@@ -1,12 +1,13 @@
 {
   "extends": "astro/tsconfigs/strictest",
   "compilerOptions": {
-    "types": ["astro/client"],
+    "types": [ "astro/client"  ],
     "baseUrl": ".",
     "paths": {
-      "@layouts/*": ["src/layouts/*"],
-      "@components/*": ["src/components/*"],
-      "@server/*": ["src/server/*"]
+      "@assets/*": [ "src/assets/*" ],
+      "@components/*": [ "src/components/*" ],
+      "@layouts/*": [ "src/layouts/*" ],
+      "@server/*": [ "src/server/*" ]
     }
   }
 }

--- a/packages/website/tsconfig.json
+++ b/packages/website/tsconfig.json
@@ -1,6 +1,12 @@
 {
   "extends": "astro/tsconfigs/strictest",
   "compilerOptions": {
-    "types": [ "astro/client" ]
+    "types": ["astro/client"],
+    "baseUrl": ".",
+    "paths": {
+      "@layouts/*": ["src/layouts/*"],
+      "@components/*": ["src/components/*"],
+      "@server/*": ["src/server/*"]
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,7 +52,6 @@ importers:
     specifiers:
       '@astrojs/node': ^4.0.0
       '@astrojs/tailwind': ^2.1.3
-      '@cyyynthia/tokenize': ^1.1.3
       '@types/node': ^18.11.18
       '@typescript-eslint/eslint-plugin': ^5.48.0
       '@typescript-eslint/parser': ^5.48.0
@@ -65,7 +64,6 @@ importers:
       tailwindcss: ^3.2.4
       typescript: ^4.9.4
     dependencies:
-      '@cyyynthia/tokenize': 1.1.3
       fast-jwt: 2.1.0
       mongodb: 4.13.0
     devDependencies:
@@ -1299,10 +1297,6 @@ packages:
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
     dev: true
-
-  /@cyyynthia/tokenize/1.1.3:
-    resolution: {integrity: sha512-sg/0tuXC2oF51vwjzAxhf7Hxb9pEOH9I/ACGb2ZUWaSCdQqK+T70Ss4xlg0KIy2pR+N43IP/B+2Uq2UpGJbJ6w==}
-    dev: false
 
   /@emmetio/abbreviation/2.2.3:
     resolution: {integrity: sha512-87pltuCPt99aL+y9xS6GPZ+Wmmyhll2WXH73gG/xpGcQ84DRnptBsI2r0BeIQ0EB/SQTOe2ANPqFqj3Rj5FOGA==}
@@ -4972,6 +4966,17 @@ packages:
     hasBin: true
     dev: true
 
+  /postcss-import/14.1.0:
+    resolution: {integrity: sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+    dependencies:
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.1
+    dev: true
+
   /postcss-import/14.1.0_postcss@8.4.21:
     resolution: {integrity: sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==}
     engines: {node: '>=10.0.0'}
@@ -4984,6 +4989,15 @@ packages:
       resolve: 1.22.1
     dev: true
 
+  /postcss-js/4.0.0:
+    resolution: {integrity: sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==}
+    engines: {node: ^12 || ^14 || >= 16}
+    peerDependencies:
+      postcss: ^8.3.3
+    dependencies:
+      camelcase-css: 2.0.1
+    dev: true
+
   /postcss-js/4.0.0_postcss@8.4.21:
     resolution: {integrity: sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==}
     engines: {node: ^12 || ^14 || >= 16}
@@ -4992,6 +5006,22 @@ packages:
     dependencies:
       camelcase-css: 2.0.1
       postcss: 8.4.21
+    dev: true
+
+  /postcss-load-config/3.1.4:
+    resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
+    engines: {node: '>= 10'}
+    peerDependencies:
+      postcss: '>=8.0.9'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      lilconfig: 2.0.6
+      yaml: 1.10.2
     dev: true
 
   /postcss-load-config/3.1.4_postcss@8.4.21:
@@ -5009,6 +5039,15 @@ packages:
       lilconfig: 2.0.6
       postcss: 8.4.21
       yaml: 1.10.2
+    dev: true
+
+  /postcss-nested/6.0.0:
+    resolution: {integrity: sha512-0DkamqrPcmkBDsLn+vQDIrtkSbNkv5AD/M322ySo9kqFkCIYklym2xEmWkwo+Y3/qZo34tzEPNUw4y7yMCdv5w==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.2.14
+    dependencies:
+      postcss-selector-parser: 6.0.11
     dev: true
 
   /postcss-nested/6.0.0_postcss@8.4.21:
@@ -5761,6 +5800,8 @@ packages:
     resolution: {integrity: sha512-AhwtHCKMtR71JgeYDaswmZXhPcW9iuI9Sp2LvZPo9upDZ7231ZJ7eA9RaURbhpXGVlrjX4cFNlB4ieTetEb7hQ==}
     engines: {node: '>=12.13.0'}
     hasBin: true
+    peerDependencies:
+      postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3
@@ -5777,10 +5818,10 @@ packages:
       object-hash: 3.0.0
       picocolors: 1.0.0
       postcss: 8.4.21
-      postcss-import: 14.1.0_postcss@8.4.21
-      postcss-js: 4.0.0_postcss@8.4.21
-      postcss-load-config: 3.1.4_postcss@8.4.21
-      postcss-nested: 6.0.0_postcss@8.4.21
+      postcss-import: 14.1.0
+      postcss-js: 4.0.0
+      postcss-load-config: 3.1.4
+      postcss-nested: 6.0.0
       postcss-selector-parser: 6.0.11
       postcss-value-parser: 4.2.0
       quick-lru: 5.1.1


### PR DESCRIPTION
Each change is divided into its own commit and these only apply to the `website` package. I separated it this way so a change can easily be removed.

- lint all with `npx eslint --ext ts src --fix`
- alias imports. (no more `../../../foo/bar.js`)
  ```yaml
  $layouts/*: "src/layouts/*"
  $components/*: "src/components/*"
  $server/*: "src/server/*"
  ```
- `/api/v1/*` was responding with `text/plain` when but giving json objects, this adds a utility function which takes the same arguments as `new Response(...)` but auto adds the header `"content-type": "application/json"`
- I forgot the license for the last commit