### PR TITLE
feat: add norwegian pronouns (incomplete)

### DIFF
--- a/packages/pronouns/src/sets.ts
+++ b/packages/pronouns/src/sets.ts
@@ -27,6 +27,8 @@
  */
 
 import * as enSets from './sets/en.js'
+import * as nbSets from './sets/nb.js'
+import * as nnSets from './sets/nn.js'
 
 export type Sets = [ string ] | [ string, string ] | [ string, string, string ]
 
@@ -61,4 +63,6 @@ export type SetDefinition = {
 
 export const PronounSets: Record<string, SetDefinition> = {
 	en: enSets,
+	nb: nbSets,
+	nn: nnSets,
 }

--- a/packages/pronouns/src/sets/nb.ts
+++ b/packages/pronouns/src/sets/nb.ts
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) Cynthia Rey et al., All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import type { Sets } from '../sets.js'
+import { formatPronounSetShort } from '../formatter.js'
+
+//!\\ CONTRIBUTORS, KEEP PRONOUNS SORTED PER CATEGORY AND ALPHABETICALLY //!\\
+
+export const sets = <const> {
+	// Nominative
+	de: {
+		classic: {
+			standard: [ 'de', 'dem' ],
+			capitalized: [ 'De', 'Dem' ],
+		},
+	},
+	det: {
+		classic: {
+			standard: [ 'det', 'det' ],
+			capitalized: [ 'Det', 'Det' ],
+		},
+	},
+	han: {
+		classic: {
+			standard: [ 'han', 'ham' ],
+			capitalized: [ 'Han', 'Ham' ],
+		},
+	},
+	hen: {
+		classic: {
+			standard: [ 'hen', 'hen' ],
+			capitalized: [ 'Hen', 'Hen' ],
+		},
+	},
+	hun: {
+		classic: {
+			standard: [ 'hun', 'henne' ],
+			capitalized: [ 'Hun', 'Henne' ],
+		},
+	},
+
+	// Meta
+	alle: {
+		classic: {
+			standard: 'Alle pronomen',
+		},
+		short: {
+			standard: 'alle',
+			capitalized: 'Alle',
+		},
+	},
+	andre: {
+		classic: {
+			standard: 'Andre pronomen',
+		},
+		short: {
+			standard: 'andre',
+			capitalized: 'Andre',
+		},
+	},
+	spør: {
+		classic: {
+			standard: 'Spør meg om pronomena mine',
+		},
+		short: {
+			standard: 'spør',
+			capitalized: 'Spør',
+		},
+	},
+	unngå: {
+		classic: {
+			standard: 'Unngå pronomen, bruk navnet mitt',
+		},
+		short: {
+			standard: 'unngå',
+			capitalized: 'Unngå',
+		},
+	},
+}
+
+export const categories = {
+	nominative: [ 'de', 'det', 'han', 'hen', 'hun' ],
+	meta: [ 'alle', 'spør', 'unngå', 'andre' ],
+}
+
+export const properties = {
+	unique: ['unngå'],
+	final: ['alle', 'spør', 'unngå', 'andre'],
+}
+
+export function formatLong (s: Sets) {
+	if (s[0] === 'spør') {
+		return 'Foretrekker å bli spurt om pronomena sine'
+	}
+
+	if (s[0] === 'unngå') {
+		return 'Vil unngå pronomen'
+	}
+
+	if (s[0] === 'andre') {
+		return 'Bruker pronomen som ikke er tilgjengelige på PronounDB'
+	}
+
+	let res = 'Bruker '
+	for (let i = 0; i < s.length; i++) {
+		const set = s[i]
+		if (set === 'spør') {
+			return `${res} pronomen. Du kan også spørre denne personen om mer informasjon`
+		}
+
+		if (set === 'andre') {
+			return `${res} pronomen. Denne personen bruker også pronomen som ikke er tilgjengelige på PronounDB`
+		}
+
+		const pronouns = formatPronounSetShort(set, false, 'nn')
+
+		if (i) {
+			res += ', '
+			if (i === s.length - 1) res += 'eller '
+		}
+
+		res += set === 'alle' ? pronouns : `"${pronouns}"`
+	}
+
+	return `${res} pronomen`
+}

--- a/packages/pronouns/src/sets/nn.ts
+++ b/packages/pronouns/src/sets/nn.ts
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) Cynthia Rey et al., All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import type { Sets } from '../sets.js'
+import { formatPronounSetShort } from '../formatter.js'
+
+//!\\ CONTRIBUTORS, KEEP PRONOUNS SORTED PER CATEGORY AND ALPHABETICALLY //!\\
+
+export const sets = <const> {
+	// Nominative
+	dei: {
+		classic: {
+			standard: [ 'dei', 'dei' ],
+			capitalized: [ 'Dei', 'Dei' ],
+		},
+	},
+	det: {
+		classic: {
+			standard: [ 'det', 'det' ],
+			capitalized: [ 'Det', 'Det' ],
+		},
+	},
+	han: {
+		classic: {
+			standard: [ 'han', 'han' ],
+			capitalized: [ 'Han', 'Han' ],
+		},
+	},
+	hen: {
+		classic: {
+			standard: [ 'hen', 'hen' ],
+			capitalized: [ 'Hen', 'Hen' ],
+		},
+	},
+	ho: {
+		classic: {
+			standard: [ 'ho', 'henne' ],
+			capitalized: [ 'Ho', 'Henne' ],
+		},
+	},
+
+	// Meta
+	alle: {
+		classic: {
+			standard: 'Alle pronomen',
+		},
+		short: {
+			standard: 'alle',
+			capitalized: 'Alle',
+		},
+	},
+	andre: {
+		classic: {
+			standard: 'Andre pronomen',
+		},
+		short: {
+			standard: 'andre',
+			capitalized: 'Andre',
+		},
+	},
+	spør: {
+		classic: {
+			standard: 'Spør meg om pronomena mine',
+		},
+		short: {
+			standard: 'spør',
+			capitalized: 'Spør',
+		},
+	},
+	unngå: {
+		classic: {
+			standard: 'Unngå pronomen, bruk namnet mitt',
+		},
+		short: {
+			standard: 'unngå',
+			capitalized: 'Unngå',
+		},
+	},
+}
+
+export const categories = {
+	nominative: [ 'dei', 'det', 'han', 'hen', 'ho' ],
+	meta: [ 'alle', 'andre', 'spør', 'unngå' ],
+}
+
+export const properties = {
+	unique: ['unngå'],
+	final: ['alle', 'andre', 'spør', 'unngå'],
+}
+
+export function formatLong (s: Sets) {
+	if (s[0] === 'spør') {
+		return 'Føretrekkjer å bli spurt om pronomena sine'
+	}
+
+	if (s[0] === 'unngå') {
+		return 'Vil unngå pronomen'
+	}
+
+	if (s[0] === 'andre') {
+		return 'Bruker pronomen som ikkje er tilgjengelege på PronounDB'
+	}
+
+	let res = 'Bruker '
+	for (let i = 0; i < s.length; i++) {
+		const set = s[i]
+		if (set === 'spør') {
+			return `${res} pronomen. Du kan òg spørja denne personen om meir informasjon`
+		}
+
+		if (set === 'andre') {
+			return `${res} pronomen. Denne personen bruker òg pronomen som ikkje er tilgjengelege på PronounDB`
+		}
+
+		const pronouns = formatPronounSetShort(set, false, 'nn')
+
+		if (i) {
+			res += ', '
+			if (i === s.length - 1) res += 'eller '
+		}
+
+		res += set === 'alle' ? pronouns : `"${pronouns}"`
+	}
+
+	return `${res} pronomen`
+}

--- a/packages/website/src/pages/wiki/api-docs.astro
+++ b/packages/website/src/pages/wiki/api-docs.astro
@@ -177,7 +177,7 @@ const flash = handleFlash(Astro)
 	<p class='mb-2'>Each locale has a list of pronouns set available to it.</p>
 	<div class='flex flex-none gap-4 items-center mb-4 px-4 py-2 font-semibold border rounded text-blue-600 border-blue-600 dark:text-blue-400 dark:border-blue-400'>
 		<div class='w-6 h-6 shrink-0' set:html={infoIcon}/>
-		<p>Only the "en" locale is supported at this time.</p>
+		<p>Only the "en", "nb", and "nn" locales are supported at this time.</p>
 	</div>
 	<ul class='list-disc list-inside mb-4'>
 		{Object.keys(PronounSets).map((locale) => (


### PR DESCRIPTION
Adds support for Norwegian pronouns (both official written languages — Bokmål and Nynorsk).

I went to begin adding the necessary support on the website to support multiple locales, however I am encountering this error both in the browser and CLI when building the website:

```
Cannot read properties of undefined (reading 'startsWith')
  Stack trace:
    at connectionStringHasValidScheme (C:\Users\Adaline\GitHub\cyyynthia\pronoundb.org\node_modules\.pnpm\mongodb-connection-string-url@3.0.0\node_modules\mongodb-connection-string-url\lib\index.js:9:30)
    at parseOptions (C:\Users\Adaline\GitHub\cyyynthia\pronoundb.org\node_modules\.pnpm\mongodb@6.3.0\node_modules\mongodb\lib\connection_string.js:186:17)
    at file:///C:/Users/Adaline/GitHub/cyyynthia/pronoundb.org/packages/website/dist/server/chunks/pages/404_qEx_xJ8G.mjs:8:16
    at async ModuleLoader.import (node:internal/modules/esm/loader:329:24)
    at async generatePages (file:///C:/Users/Adaline/GitHub/cyyynthia/pronoundb.org/node_modules/.pnpm/astro@4.2.1_@types+node@20.11.5_typescript@5.3.3/node_modules/astro/dist/core/build/generate.js:141:11)
 ELIFECYCLE  Command failed with exit code 1.
```

I didn't have time to investigate tonight, wondering if @cyyynthia you have any idea off the top of your head what might be the issue here.